### PR TITLE
Use `globalThis` for the `fetch` default

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function request(
 		},
 		clientId = defaultClientId,
 		timeout = 10000,
-		fetch = window.fetch,
+		fetch = globalThis.fetch,
 		version,
 		query,
 		data,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@paylike/request",
-	"version": "3.0.2",
+	"version": "3.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@paylike/request",
-			"version": "3.0.2",
+			"version": "3.1.0",
 			"dependencies": {
 				"http-querystring-stringify": "^2.0.0",
 				"json-parse-safe": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "@paylike/request",
 	"version": "3.0.2",
 	"repository": "paylike/js-request",
+	"main": "index.js",
 	"scripts": {
 		"test": "node test"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@paylike/request",
-	"version": "3.0.2",
+	"version": "3.1.0",
 	"repository": "paylike/js-request",
 	"main": "index.js",
 	"scripts": {

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,8 @@ further context.
 ## Example
 
 ```js
-const request = require('@paylike/request')
+// swap esm.sh for any "npm CJS to ESM CDN"
+import request from 'https://esm.sh/@paylike/request@3.0.2'
 
 const token = request('vault.paylike.io', {
   version: 1,

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ further context.
 
 ```js
 // swap esm.sh for any "npm CJS to ESM CDN"
-import request from 'https://esm.sh/@paylike/request@3.0.2'
+import request from 'https://esm.sh/@paylike/request@3.1.0'
 
 const token = request('vault.paylike.io', {
   version: 1,

--- a/readme.md
+++ b/readme.md
@@ -6,12 +6,6 @@ This is a low-level library used for making HTTP(s) requests to Paylike APIs. It
 incorporates the conventions described in the
 [Paylike API reference](https://github.com/paylike/api-reference).
 
-It is built to work in any JavaScript environment (Node.js, browser) by
-accepting a [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
-implementation as input. Minor tweaks are implemented to support the
-[`node-fetch`](https://github.com/node-fetch/node-fetch) implementation even
-though it is not entirely compatible.
-
 This function is usually put behind a retry mechanism. Paylike APIs _will_
 expect any client to gracefully handle a rate limiting response and expects them
 to retry.
@@ -131,3 +125,11 @@ function retry(fn, should, attempts = 0) {
   from the API reference. They have at least a `code` and `message` property,
   but may also have other useful properties relevant to the specific error code,
   such as a minimum and maximum for amounts.
+
+### Custom `fetch` (e.g. Node.js v16 and older)
+
+It is built to work in any JavaScript environment (Node.js, browser) by
+accepting a [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+implementation as input. Minor tweaks are implemented to support the
+[`node-fetch`](https://github.com/node-fetch/node-fetch) implementation even
+though it is not entirely compatible.

--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,9 @@ further context.
 ## Example
 
 ```js
-const fetch = require('node-fetch') // necessary only for Node.js support
 const request = require('@paylike/request')
 
 const token = request('vault.paylike.io', {
-  fetch,
   version: 1,
   data: {type: 'pcn', value: '1000 0000 0000 0000'.replaceAll(' ', '')},
 }).first()
@@ -42,7 +40,7 @@ request(
   endpoint, // String, required
   {
     log: () => {},
-    fetch: window.fetch, // required in e.g. Node.js
+    fetch: globalThis.fetch, // required in older Node.js
     timeout: 10000, // 0 = disabled
 
     version: String, // required


### PR DESCRIPTION
With `fetch` coming to Node.js, this package can work out-of-the-box if using the correct reference to the global object.